### PR TITLE
Make tables auto populating with {} if accessing non existant key

### DIFF
--- a/lua/luasnip/session/snippet_collection.lua
+++ b/lua/luasnip/session/snippet_collection.lua
@@ -10,6 +10,28 @@ local M = {
 	invalidated_count = 0,
 }
 
+do
+	local auto
+	function auto(self, key, depth)
+		print("auto", key)
+		local t = {}
+		if depth ~= 1 then
+			setmetatable(t, {
+			-- TODO not sure if this is that nice, creating a new function on
+			-- each time (lua-users does this by a seperate mamber)
+				__index = function(s,k) return auto(s,k,depth-1) end,
+			})
+		end
+		self[key] = t
+		return t
+	end
+	function AutomagicTable(depth)
+		return setmetatable({}, {__index = function(s,k) return auto(s,k, depth or 0) end})
+	end
+end
+-- TODO use AutomagicTable with by_prio.autosnippets(2), by_prio.snippets(2)
+-- TODO use AutomagicTable with by_ft.autosnippets(1), by_ft.snippets(1)
+
 local by_key = {}
 
 -- stores snippets/autosnippets by priority.


### PR DESCRIPTION
TODO:
- [x] AutomagicTable with `by_prio.autosnippets` and `by_prio.snippets`
"Problem" here is that there is already a metatable for sorted insert (so we have to merge these with nice code)
- [x] AutomagicTable with `by_ft.autosnippets` and `by_ft.snippets`
- [ ] Benchmark if this is worth it and check if creating new functions for each created table is nice or if depth should be checked via a table member
- [ ] check at which places now `rawget()` has to be used (it this nice code style?) to check if a key exists